### PR TITLE
apq8084-common: nuke charging speed indication

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res-keyguard/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res-keyguard/values/config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized -->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- Threshold in micro watts below which a charger is rated as "slow"; 1A @ 5V -->
+    <integer name="config_chargingSlowlyThreshold">0</integer>
+
+</resources>


### PR DESCRIPTION
* Samsung uses a different method to control charging voltage/current.
  Current and voltage values in power_supply/charger is not correct.

* Nuke this for now.

Change-Id: Ie86c291e18a19dd592ec97cf200762394c797ad7